### PR TITLE
Fix: Prevent clubs from booking more places than their available points

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,9 +50,15 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
+    if int(club['points']) >= placesRequired:
+        competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+        club['points'] = str(int(club['points']) - placesRequired)
+        flash('Great-booking complete!')
+    else:
+        flash(f"You do not have enough points to book {placesRequired} places. You currently have {club['points']} points.")
+    
     return render_template('welcome.html', club=club, competitions=competitions)
+
 
 
 # TODO: Add route for points display


### PR DESCRIPTION
This PR resolves the bug where clubs could book more places than their available points allowed, violating the functional specification that "Each club can see its current balance and exchange points for athlete registrations at future competitions, at a rate of one point per registration".