### PR TITLE
Fix: Limit club bookings to a maximum of 12 places per competition

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,6 +50,9 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+    if placesRequired > 12:
+        flash("You cannot book more than 12 places per competition.")
+        return render_template('welcome.html', club=club, competitions=competitions)
     if int(club['points']) >= placesRequired:
         competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
         club['points'] = str(int(club['points']) - placesRequired)


### PR DESCRIPTION
It addresses the bug where clubs could book more than 12 places for a single competition, which goes against the functional specification: "chaque club ne peut inscrire qu'un maximum de 12 athlètes."