### PR TITLE
Fix: Prevent booking places in past competitions and grey out links

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -9,6 +9,11 @@
             "name": "Fall Classic",
             "date": "2020-10-22 13:30:00",
             "numberOfPlaces": "13"
+        },
+        {
+            "name": "Summer 2025",
+            "date": "2025-07-22 13:30:00",
+            "numberOfPlaces": "10"
         }
     ]
 }

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import json
 from flask import Flask,render_template,request,redirect,flash,url_for
+from datetime import datetime
 
 
 def loadClubs():
@@ -29,7 +30,7 @@ def showSummary():
     found_clubs = [club for club in clubs if club['email'] == request.form['email']]
     if found_clubs: 
         club = found_clubs[0]
-        return render_template('welcome.html',club=club,competitions=competitions)
+        return render_template('welcome.html',club=club,competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
     else:
         flash("Sorry, that email was not found.")
         return redirect(url_for('index'))
@@ -38,21 +39,28 @@ def showSummary():
 def book(competition,club):
     foundClub = [c for c in clubs if c['name'] == club][0]
     foundCompetition = [c for c in competitions if c['name'] == competition][0]
+    competition_date = datetime.strptime(foundCompetition['date'], '%Y-%m-%d %H:%M:%S')
+    if competition_date < datetime.now():
+        flash("This competition has already passed. Booking is not allowed.")
+        return render_template('welcome.html', club=foundClub, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
     if foundClub and foundCompetition:
         return render_template('booking.html',club=foundClub,competition=foundCompetition)
     else:
         flash("Something went wrong-please try again")
-        return render_template('welcome.html', club=club, competitions=competitions)
-
+        return render_template('welcome.html', club=foundClub, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+    competition_date = datetime.strptime(competition['date'], '%Y-%m-%d %H:%M:%S')
+    if competition_date < datetime.now():
+        flash("Booking for past competitions is not allowed.")
+        return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
     if placesRequired > 12:
         flash("You cannot book more than 12 places per competition.")
-        return render_template('welcome.html', club=club, competitions=competitions)
+        return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
     if int(club['points']) >= placesRequired:
         competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
         club['points'] = str(int(club['points']) - placesRequired)
@@ -60,7 +68,7 @@ def purchasePlaces():
     else:
         flash(f"You do not have enough points to book {placesRequired} places. You currently have {club['points']} points.")
     
-    return render_template('welcome.html', club=club, competitions=competitions)
+    return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
 
 

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -23,9 +23,16 @@
             {{comp['name']}}<br />
             Date: {{comp['date']}}</br>
             Number of Places: {{comp['numberOfPlaces']}}
-            {%if comp['numberOfPlaces']|int >0%}
-            <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
-            {%endif%}
+            {# Compare competition date string with current_date_str #}
+            {% if comp['date'] > current_date_str and comp['numberOfPlaces']|int > 0 %}
+                <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
+            {% else %}
+                {% if comp['date'] <= current_date_str %}
+                    <span style="color: gray;">(Competition passed)</span>
+                {% else %}
+                    <span style="color: gray;">(No places left)</span>
+                {% endif %}
+            {% endif %}
         </li>
         <hr />
         {% endfor %}


### PR DESCRIPTION
It resolves the critical bug where clubs could attempt to book places for competitions that have already occurred. This fix implements both a user-friendly frontend indication and robust backend validation to ensure only future competitions can be booked.