### PR TITLE
Fix: Persist club points and competition places after booking

### DIFF
--- a/clubs.json
+++ b/clubs.json
@@ -1,16 +1,19 @@
-{"clubs":[
-    {
-        "name":"Simply Lift",
-        "email":"john@simplylift.co",
-        "points":"13"
-    },
-    {
-        "name":"Iron Temple",
-        "email": "admin@irontemple.com",
-        "points":"4"
-    },
-    {   "name":"She Lifts",
-        "email": "kate@shelifts.co.uk",
-        "points":"12"
-    }
-]}
+{
+    "clubs": [
+        {
+            "name": "Simply Lift",
+            "email": "john@simplylift.co",
+            "points": "10"
+        },
+        {
+            "name": "Iron Temple",
+            "email": "admin@irontemple.com",
+            "points": "4"
+        },
+        {
+            "name": "She Lifts",
+            "email": "kate@shelifts.co.uk",
+            "points": "12"
+        }
+    ]
+}

--- a/competitions.json
+++ b/competitions.json
@@ -13,7 +13,7 @@
         {
             "name": "Summer 2025",
             "date": "2025-07-22 13:30:00",
-            "numberOfPlaces": "10"
+            "numberOfPlaces": 7
         }
     ]
 }

--- a/server.py
+++ b/server.py
@@ -8,11 +8,18 @@ def loadClubs():
          listOfClubs = json.load(c)['clubs']
          return listOfClubs
 
-
 def loadCompetitions():
     with open('competitions.json') as comps:
          listOfCompetitions = json.load(comps)['competitions']
          return listOfCompetitions
+
+def saveClubs(clubs_data):
+    with open('clubs.json', 'w') as c:
+        json.dump({"clubs": clubs_data}, c, indent=4)
+
+def saveCompetitions(competitions_data):
+    with open('competitions.json', 'w') as comps:
+        json.dump({"competitions": competitions_data}, comps, indent=4)
 
 
 app = Flask(__name__)
@@ -28,48 +35,62 @@ def index():
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
     found_clubs = [club for club in clubs if club['email'] == request.form['email']]
-    if found_clubs: 
+
+    if found_clubs:
         club = found_clubs[0]
         return render_template('welcome.html',club=club,competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
     else:
         flash("Sorry, that email was not found.")
         return redirect(url_for('index'))
 
+
 @app.route('/book/<competition>/<club>')
 def book(competition,club):
     foundClub = [c for c in clubs if c['name'] == club][0]
     foundCompetition = [c for c in competitions if c['name'] == competition][0]
+    
     competition_date = datetime.strptime(foundCompetition['date'], '%Y-%m-%d %H:%M:%S')
     if competition_date < datetime.now():
         flash("This competition has already passed. Booking is not allowed.")
         return render_template('welcome.html', club=foundClub, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+    
     if foundClub and foundCompetition:
         return render_template('booking.html',club=foundClub,competition=foundCompetition)
     else:
         flash("Something went wrong-please try again")
         return render_template('welcome.html', club=foundClub, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
+
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+
     competition_date = datetime.strptime(competition['date'], '%Y-%m-%d %H:%M:%S')
     if competition_date < datetime.now():
         flash("Booking for past competitions is not allowed.")
         return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+
     if placesRequired > 12:
         flash("You cannot book more than 12 places per competition.")
         return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+
     if int(club['points']) >= placesRequired:
-        competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-        club['points'] = str(int(club['points']) - placesRequired)
-        flash('Great-booking complete!')
+        if int(competition['numberOfPlaces']) >= placesRequired:
+            competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+            club['points'] = str(int(club['points']) - placesRequired)
+
+            saveClubs(clubs)
+            saveCompetitions(competitions)
+
+            flash('Great-booking complete!')
+        else:
+            flash(f"Not enough places available in this competition. Only {competition['numberOfPlaces']} places left.")
     else:
         flash(f"You do not have enough points to book {placesRequired} places. You currently have {club['points']} points.")
     
     return render_template('welcome.html', club=club, competitions=competitions, current_date_str=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
-
 
 
 # TODO: Add route for points display


### PR DESCRIPTION
This Pull Request addresses the bug where changes to club points and competition numberOfPlaces were not persistent across server restarts. Previously, these values would revert to their initial states as loaded from clubs.json and competitions.json because in-memory updates were not written back to disk.