### PR TITLE
feat: Add public link to points display board on index page

### DIFF
--- a/server.py
+++ b/server.py
@@ -131,11 +131,7 @@ def purchasePlaces():
 
 
 @app.route('/pointsDisplay')
-def pointsDisplay():
-    if 'club_email' not in session:
-        flash("You need to be logged in to view club points.")
-        return redirect(url_for('index'))
-        
+def pointsDisplay():      
     sorted_clubs = sorted(clubs, key=lambda c: int(c['points']), reverse=True)
     return render_template('points.html', clubs=sorted_clubs)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,18 +7,15 @@
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
     
-    {# Add this block to display flashed messages #}
-    {% with messages = get_flashed_messages()%}
-    {% if messages %}
-        <ul>
-       {% for message in messages %}
-            <li>{{message}}</li>
-        {% endfor %}
-       </ul>
-    {% endif%}
-    {%endwith%}
+    <p>
+        <a href="{{ url_for('pointsDisplay') }}">View Public Club Points Board</a>
+    </p>
 
-    Please enter your secretary email to continue:
+    <hr/> {# Optional: Add a separator for better visual distinction #}
+
+    <p>
+        Please enter your secretary email to continue:
+    </p>
     <form action="showSummary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>


### PR DESCRIPTION
This Pull Request makes the "Club Points Leaderboard" publicly accessible directly from the application's homepage (index.html), fulfilling the Phase 2 requirement that the public points board should not require login.