### PR TITLE
Bug/fix unknown email crash

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 import json
-from flask import Flask,render_template,request,redirect,flash,url_for
+from flask import Flask,render_template,request,redirect,flash,url_for,session
 
 
 def loadClubs():
@@ -24,10 +24,20 @@ clubs = loadClubs()
 def index():
     return render_template('index.html')
 
+
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    user_email = request.form['email']
+    found_clubs = [club for club in clubs if club['email'] == user_email]
+
+    if found_clubs:
+        club = found_clubs[0]
+        session['club_email'] = club['email']
+        return render_template('welcome.html',club=club,competitions=competitions)
+    else:
+        flash("Sorry, that email was not found.")
+        session.pop('club_email', None)
+        return redirect(url_for('index'))
 
 
 @app.route('/book/<competition>/<club>')

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GUDLFT Registration</title>
+    <style>
+        .error-message {
+            color: red;
+        }
+    </style>
 </head>
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
@@ -12,5 +17,13 @@
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>
     </form>
+    
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        {% for message in messages %}
+          <p class="error-message">{{ message }}</p>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
 </body>
 </html>

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,40 @@
+import pytest
+from server import app, clubs, competitions
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def client():
+    """Configures the Flask test client and yields it for testing."""
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_unknown_email_flashes_message(client):
+    """Test that an unknown email results in a flash message being stored."""
+    # Mock the 'clubs' data so that the email is not found
+    with patch('server.clubs', []):
+        response = client.post('/showSummary', data={'email': 'unknown@test.com'}, follow_redirects=False)
+
+        # Check the flash messages stored in the session
+        with client.session_transaction() as sess:
+            flashed_messages = dict(sess.get('_flashes', []))
+            
+        assert response.status_code == 302
+        assert response.location == '/'
+        assert "Sorry, that email was not found." in flashed_messages.values()
+
+def test_existing_email_login_is_successful(client):
+    """Test that a user with an existing email can log in and view the welcome page."""
+    # Mock the 'clubs' data to include a known user
+    with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '10'}]):
+        response = client.post('/showSummary', data={'email': 'test@test.com'})
+
+        # Assertions
+        assert response.status_code == 200
+        assert b'Welcome' in response.data
+        
+        # Check that the email was stored in the session
+        with client.session_transaction() as sess:
+            assert 'club_email' in sess
+            assert sess['club_email'] == 'test@test.com'


### PR DESCRIPTION
This pull request addresses a critical bug where the application would crash when a user entered an unknown email address on the login page. The original code assumed a club would always be found in the clubs list and attempted to access the first element, which would cause an IndexError if the list was empty.

This fix modifies the showSummary() function in server.py to correctly handle this exception.

Changes Made:

    Error Handling: The code now checks if the found_clubs list is empty.

User Feedback: If no club is found, a flash message "Sorry, that email was not found." is displayed to the user.

Redirection: The user is then redirected back to the index page to try again.

    Session Management: The session is cleared to ensure no invalid user data persists.

Verification:

    Manual Test: I manually tested the fix by entering an unknown email, and the application now redirects to the home page with the correct error message displayed.

    Automated Test: The test_unknown_email_flashes_message() test in tests/test_login.py now passes successfully, confirming the fix. This test case was written specifically to encapsulate the problem and its solution.