### PR TITLE
Bug/prevent overspending points

### DIFF
--- a/server.py
+++ b/server.py
@@ -27,8 +27,7 @@ def index():
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
-    user_email = request.form['email']
-    found_clubs = [club for club in clubs if club['email'] == user_email]
+    found_clubs = [club for club in clubs if club['email'] == request.form['email']]
 
     if found_clubs:
         club = found_clubs[0]
@@ -56,10 +55,23 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+
+    # Check if club has enough points
+    if int(club['points']) < placesRequired:
+        flash(f"You do not have enough points to book {placesRequired} places. You currently have {club['points']} points.")
+        return redirect(url_for('book', competition=competition['name'], club=club['name']))
+
+    # Check if competition has enough places
+    if int(competition['numberOfPlaces']) < placesRequired:
+        flash(f"Not enough places available in this competition. Only {competition['numberOfPlaces']} places left.")
+        return redirect(url_for('book', competition=competition['name'], club=club['name']))
+
+    # Proceed with purchase only if all conditions are met
+    competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+    club['points'] = str(int(club['points']) - placesRequired)
+    
     flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
-
 
 # TODO: Add route for points display
 

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -3,6 +3,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Booking for {{competition['name']}} || GUDLFT</title>
+    <style>
+        .error-message {
+            color: red;
+        }
+    </style>
 </head>
 <body>
     <h2>{{competition['name']}}</h2>
@@ -10,8 +15,18 @@
     <form action="/purchasePlaces" method="post">
         <input type="hidden" name="club" value="{{club['name']}}">
         <input type="hidden" name="competition" value="{{competition['name']}}">
-        <label for="places">How many places?</label><input type="number" name="places" id=""/>
+        <label for="places">How many places?</label><input type="number" name="places" id="places"/>
         <button type="submit">Book</button>
     </form>
+    
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul class="flashes">
+        {% for message in messages %}
+          <li class="error-message">{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
 </body>
 </html>

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,0 +1,50 @@
+import pytest
+from server import app
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_purchase_with_insufficient_points(client):
+    """Test that a purchase is blocked when the club has insufficient points."""
+    with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '10'}]):
+        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20'}]):
+            with patch('server.flash') as mock_flash:
+                response = client.post('/purchasePlaces', data={
+                    'club': 'Test Club',
+                    'competition': 'Test Competition',
+                    'places': '11'
+                }, follow_redirects=False)
+
+                mock_flash.assert_called_once_with("You do not have enough points to book 11 places. You currently have 10 points.")
+                assert response.status_code == 302
+                assert response.location == '/book/Test%20Competition/Test%20Club'
+
+
+def test_purchase_with_sufficient_points_and_places_without_save(client):
+    """Test a successful purchase with enough points and places without relying on save functions."""
+    # Mock the lists to set up the test scenario
+    mock_clubs = [{'name': 'Test Club', 'email': 'test@test.com', 'points': '10'}]
+    mock_competitions = [{'name': 'Test Competition', 'numberOfPlaces': '20'}]
+
+    with patch('server.clubs', mock_clubs):
+        with patch('server.competitions', mock_competitions):
+            with patch('server.flash') as mock_flash:
+                response = client.post('/purchasePlaces', data={
+                    'club': 'Test Club',
+                    'competition': 'Test Competition',
+                    'places': '5'
+                }, follow_redirects=False)
+
+                # Assertions for the happy path
+                mock_flash.assert_called_once_with("Great-booking complete!")
+                assert response.status_code == 200
+                assert b'Welcome' in response.data
+                # Verify that the points and places were updated in the mock data
+                assert mock_clubs[0]['points'] == '5'
+                assert mock_competitions[0]['numberOfPlaces'] == 15


### PR DESCRIPTION
This pull request addresses the bug where clubs were able to book more places than their available points would allow. The original implementation of the purchasePlaces function did not perform a check to see if the club had enough points to cover the cost of the required places. This fix implements a validation step to prevent clubs from overspending.

Changes Made:

    Validation Logic: A new conditional check has been added to the purchasePlaces function to compare the club's available points with the placesRequired variable.

    Error Handling: If a club attempts to book more places than their points can cover (at a rate of 1 point per place ), an error message is flashed to the user.

    No Deductions: The points are only deducted from the club's total if the booking is successful and the club has sufficient points.

Verification:

    Manual Test: I manually tested the booking process with a club having fewer points than the places they tried to book. The application now displays the appropriate error message and does not deduct any points.

    Automated Test: An automated test has been created to cover this specific scenario, confirming that the bug is fixed and the correct behavior is in place.