### PR TITLE
Bug/fix booking limit 12

### DIFF
--- a/server.py
+++ b/server.py
@@ -56,6 +56,11 @@ def purchasePlaces():
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
 
+    # FIX for Bug 3: Block bookings over 12 places
+    if placesRequired > 12:
+        flash("You cannot book more than 12 places per competition.")
+        return redirect(url_for('book', competition=competition['name'], club=club['name']))
+
     # Check if club has enough points
     if int(club['points']) < placesRequired:
         flash(f"You do not have enough points to book {placesRequired} places. You currently have {club['points']} points.")

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -48,3 +48,19 @@ def test_purchase_with_sufficient_points_and_places_without_save(client):
                 # Verify that the points and places were updated in the mock data
                 assert mock_clubs[0]['points'] == '5'
                 assert mock_competitions[0]['numberOfPlaces'] == 15
+
+
+def test_purchase_more_than_max_places(client):
+    """Test that a club cannot book more than 12 places per competition."""
+    with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '20'}]):
+        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20'}]):
+            with patch('server.flash') as mock_flash:
+                response = client.post('/purchasePlaces', data={
+                    'club': 'Test Club',
+                    'competition': 'Test Competition',
+                    'places': '13'
+                }, follow_redirects=False)
+
+                mock_flash.assert_called_once_with("You cannot book more than 12 places per competition.")
+                assert response.status_code == 302
+                assert response.location == '/book/Test%20Competition/Test%20Club'


### PR DESCRIPTION
Description:

This pull request fixes a bug that allowed clubs to book more than 12 places per competition, which violates a key functional requirement of the application. The original purchasePlaces function did not check if the requested number of places exceeded the 12-place limit for a single club. This fix implements the necessary validation to enforce this rule.

Changes Made:

    Validation Logic: A conditional check has been added to the purchasePlaces function to verify that the placesRequired variable does not exceed 12.

    User Feedback: If a user attempts to book more than 12 places, an error message is displayed to them.

    No Deductions: Points and competition places are only deducted if the requested number of places is within the allowed limit.

Verification:

    Manual Test: I manually tested the booking process with a request for 13 places. The application now correctly displays an error message and prevents the booking.

    Automated Test: An automated test has been created to cover this scenario, ensuring that the bug is fixed and that future changes don't reintroduce it.