### PR TITLE
Bug/fix past competition booking

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -9,6 +9,11 @@
             "name": "Fall Classic",
             "date": "2020-10-22 13:30:00",
             "numberOfPlaces": "13"
+        },
+        {
+            "name": "Winter Classic",
+            "date": "2025-12-25 13:30:00",
+            "numberOfPlaces": "18"
         }
     ]
 }

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from flask import Flask,render_template,request,redirect,flash,url_for,session
 
 
@@ -55,6 +56,12 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+
+    # FIX for Bug 4: Block bookings for past competitions
+    competition_date = datetime.strptime(competition['date'], "%Y-%m-%d %H:%M:%S")
+    if competition_date < datetime.now():
+        flash("Booking for past competitions is not allowed.")
+        return redirect(url_for('book', competition=competition['name'], club=club['name']))
 
     # FIX for Bug 3: Block bookings over 12 places
     if placesRequired > 12:

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,5 +1,6 @@
 import pytest
 from server import app
+from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 
@@ -13,7 +14,7 @@ def client():
 def test_purchase_with_insufficient_points(client):
     """Test that a purchase is blocked when the club has insufficient points."""
     with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '10'}]):
-        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20'}]):
+        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20', 'date': '2025-12-31 09:00:00'}]):
             with patch('server.flash') as mock_flash:
                 response = client.post('/purchasePlaces', data={
                     'club': 'Test Club',
@@ -30,7 +31,7 @@ def test_purchase_with_sufficient_points_and_places_without_save(client):
     """Test a successful purchase with enough points and places without relying on save functions."""
     # Mock the lists to set up the test scenario
     mock_clubs = [{'name': 'Test Club', 'email': 'test@test.com', 'points': '10'}]
-    mock_competitions = [{'name': 'Test Competition', 'numberOfPlaces': '20'}]
+    mock_competitions = [{'name': 'Test Competition', 'numberOfPlaces': '20', 'date': '2025-12-31 09:00:00'}]
 
     with patch('server.clubs', mock_clubs):
         with patch('server.competitions', mock_competitions):
@@ -46,14 +47,14 @@ def test_purchase_with_sufficient_points_and_places_without_save(client):
                 assert response.status_code == 200
                 assert b'Welcome' in response.data
                 # Verify that the points and places were updated in the mock data
-                assert mock_clubs[0]['points'] == '5'
-                assert mock_competitions[0]['numberOfPlaces'] == 15
+                assert int(mock_clubs[0]['points']) == 5
+                assert int(mock_competitions[0]['numberOfPlaces']) == 15
 
 
 def test_purchase_more_than_max_places(client):
     """Test that a club cannot book more than 12 places per competition."""
     with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '20'}]):
-        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20'}]):
+        with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20', 'date': '2025-12-31 09:00:00'}]):
             with patch('server.flash') as mock_flash:
                 response = client.post('/purchasePlaces', data={
                     'club': 'Test Club',
@@ -62,5 +63,27 @@ def test_purchase_more_than_max_places(client):
                 }, follow_redirects=False)
 
                 mock_flash.assert_called_once_with("You cannot book more than 12 places per competition.")
+                assert response.status_code == 302
+                assert response.location == '/book/Test%20Competition/Test%20Club'
+
+
+def test_purchase_on_past_competition(client):
+    """Test that a purchase is blocked for a past competition."""
+    # Patch the datetime class imported in server.py and give it a mock 'now' method.
+    from datetime import datetime as original_datetime
+    with patch('server.datetime') as mock_datetime:
+        mock_datetime.now = MagicMock(return_value=original_datetime(2025, 1, 1, 10, 0, 0))
+        mock_datetime.strptime.side_effect = original_datetime.strptime
+        
+        with patch('server.clubs', [{'name': 'Test Club', 'email': 'test@test.com', 'points': '20'}]):
+            with patch('server.competitions', [{'name': 'Test Competition', 'numberOfPlaces': '20', 'date': '2024-12-31 09:00:00'}]):
+                with patch('server.flash') as mock_flash:
+                    response = client.post('/purchasePlaces', data={
+                        'club': 'Test Club',
+                        'competition': 'Test Competition',
+                        'places': '5'
+                    }, follow_redirects=False)
+
+                mock_flash.assert_called_once_with("Booking for past competitions is not allowed.")
                 assert response.status_code == 302
                 assert response.location == '/book/Test%20Competition/Test%20Club'


### PR DESCRIPTION
This pull request addresses the bug that allowed users to book places in competitions that have already taken place. The original purchasePlaces function did not check the competition's date, allowing for bookings to be made after the event has passed. This fix implements the necessary validation to ensure that bookings can only be made for future competitions.

Changes Made:

    Date Validation: The purchasePlaces function has been modified to compare the competition's date with the current date and time.

    User Feedback: If a user attempts to book a place in a past competition, a clear error message is flashed to the screen to inform them of the issue.

    No Deductions: Points are not deducted, and competition places are not updated if the booking is invalid.

Verification:

    Manual Test: I manually tested the booking process for a competition with a past date. The application now correctly displays the error message and prevents the booking from being processed.

    Automated Test: The automated test for this bug now passes, confirming that the fix is implemented correctly and the application behaves as expected.