### PR TITLE
Feat/points display board

### DIFF
--- a/templates/points.html
+++ b/templates/points.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Points Display</title>
+</head>
+<body>
+    <h1>Club Points Board</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Club</th>
+                <th>Points</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for club in clubs %}
+            <tr>
+                <td>{{ club.name }}</td>
+                <td>{{ club.points }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <br>
+    <a href="{{ url_for('showSummary') }}">Back to Welcome</a>
+</body>
+</html>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -6,6 +6,7 @@
 </head>
 <body>
         <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a>
+        <a href="{{ url_for('pointsDisplay') }}">View Club Points</a>
 
     {% with messages = get_flashed_messages()%}
     {% if messages %}

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,43 @@
+import pytest
+from server import app
+from unittest.mock import patch
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+# Mock data to simulate the clubs with different point values
+MOCK_CLUBS_DATA = [
+    {'name': 'Club Alpha', 'email': 'alpha@test.com', 'points': '5'},
+    {'name': 'Club Beta', 'email': 'beta@test.com', 'points': '20'},
+    {'name': 'Club Gamma', 'email': 'gamma@test.com', 'points': '10'}
+]
+
+
+@patch('server.clubs', MOCK_CLUBS_DATA)
+def test_points_display_board(client):
+    """
+    Test that the points display board loads and correctly sorts clubs by points.
+    """
+    response = client.get('/pointsDisplay')
+    
+    # Assert that the page loads successfully
+    assert response.status_code == 200
+    assert b"Club Points Board" in response.data
+    
+    # Assert that the clubs are displayed in the correct sorted order (descending)
+    data = response.data.decode('utf-8')
+    assert "Club Beta" in data
+    assert "Club Gamma" in data
+    assert "Club Alpha" in data
+    
+    # A more robust check for order: find the index of each club name in the response.
+    beta_index = data.find("Club Beta")
+    gamma_index = data.find("Club Gamma")
+    alpha_index = data.find("Club Alpha")
+    
+    assert beta_index < gamma_index < alpha_index


### PR DESCRIPTION
This pull request implements the new feature for a public-facing points display board, as outlined in the project specifications. The goal is to improve transparency by providing a real-time, read-only scoreboard of all clubs and their available points.

Changes Made:

    New pointsDisplay Route: A dedicated route has been created at /pointsDisplay to handle the new feature.

    Public Access: The scoreboard is accessible without the need for a user to log in to the application.

    Sorted Display: The clubs are dynamically sorted in descending order based on their point totals, ensuring the most up-to-date standings are always visible.

Verification:

    Manual Test: I manually navigated to the /pointsDisplay route in the browser without being logged in. The scoreboard displayed correctly and was sorted by the number of points.

    Automated Test: A new automated test was added to verify that the route is accessible and that the data is rendered in the correct order.